### PR TITLE
Fix url of posts.

### DIFF
--- a/scripts/kowabana_notification.coffee
+++ b/scripts/kowabana_notification.coffee
@@ -18,7 +18,7 @@ module.exports = (robot) ->
     post_name = post_type_map["#{post.type}"]
 
     "#{kowabana_host}/users/#{user.id}|#{user.name} さんが
-    #{kowabana_host}/#{post.type}/#{post.id}|#{post.title}(#{post_name})
+    #{kowabana_host}/#{post.relative_url}|#{post.title}(#{post_name})
     を投稿しました。"
 
   robot.router.post "/hubot/new_posting_notification", (req, res) ->


### PR DESCRIPTION
[#1878](https://github.com/fjordllc/kowabana/issues/1878) の対応
Rails側で送るjsonのpostにrelative_url要素を追加